### PR TITLE
Fix issue where data is lost if fieldName for context and metadata is the same

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loglayer",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "A wrapper around logging libraries to provide a consistent way to specify context, metadata, and errors.",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/LogLayer.ts
+++ b/src/LogLayer.ts
@@ -241,9 +241,22 @@ export class LogLayer<ExternalLogger extends LoggerLibrary = LoggerLibrary, Erro
     let d = {}
 
     if (hasObjData) {
-      d = {
-        ...this.formatContext(),
-        ...this.formatMetadata(data),
+      // Field names for context and metadata is the same, merge the metadata into the same field name
+      if (this._config.context.fieldName && this._config.context.fieldName === this._config.metadata.fieldName) {
+        const contextData = this.formatContext()[this._config.context.fieldName]
+        const metadata = this.formatMetadata(data)[this._config.metadata.fieldName]
+
+        d = {
+          [this._config.context.fieldName]: {
+            ...contextData,
+            ...metadata,
+          },
+        }
+      } else {
+        d = {
+          ...this.formatContext(),
+          ...this.formatMetadata(data),
+        }
       }
     }
 

--- a/src/__tests__/generic.test.ts
+++ b/src/__tests__/generic.test.ts
@@ -349,10 +349,13 @@ describe('loglayer general tests', () => {
       )
     })
 
-    it('should use a custom context field', () => {
+    it('should use a custom context and metadata field', () => {
       const log = getLogger({
         context: {
           fieldName: 'myContext',
+        },
+        metadata: {
+          fieldName: 'myMetadata',
         },
       })
 
@@ -362,7 +365,11 @@ describe('loglayer general tests', () => {
         reqId: 1234,
       })
 
-      log.info('a request')
+      log
+        .withMetadata({
+          my: 'metadata',
+        })
+        .info('a request')
 
       expect(log.getContext()).toStrictEqual({
         reqId: 1234,
@@ -376,8 +383,69 @@ describe('loglayer general tests', () => {
               myContext: {
                 reqId: 1234,
               },
+              myMetadata: {
+                my: 'metadata',
+              },
             },
             'a request',
+          ],
+        }),
+      )
+    })
+
+    it('should use a custom metadata field', () => {
+      const log = getLogger({
+        metadata: {
+          fieldName: 'myMetadata',
+        },
+      })
+
+      const genericLogger = log.getLoggerInstance()
+
+      log.metadataOnly({
+        my: 'metadata',
+      })
+
+      expect(genericLogger.getLine()).toStrictEqual(
+        expect.objectContaining({
+          level: LogLevel.info,
+          data: [
+            {
+              myMetadata: {
+                my: 'metadata',
+              },
+            },
+          ],
+        }),
+      )
+    })
+
+    it('should merge metadata and context fields if they are the same field name', () => {
+      const log = getLogger({
+        metadata: {
+          fieldName: 'sharedData',
+        },
+        context: {
+          fieldName: 'sharedData',
+        },
+      })
+
+      const genericLogger = log.getLoggerInstance()
+
+      log.withContext({ ctx: 'data' }).metadataOnly({
+        my: 'metadata',
+      })
+
+      expect(genericLogger.getLine()).toStrictEqual(
+        expect.objectContaining({
+          level: LogLevel.info,
+          data: [
+            {
+              sharedData: {
+                my: 'metadata',
+                ctx: 'data',
+              },
+            },
           ],
         }),
       )


### PR DESCRIPTION
If you configure the context and metadata `fieldName` to have the same name, only the metadata is captured, while the context is lost.

The data is now merged into the shared field.