### PR TITLE
Add hooks feature, add onBeforeDataOut hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loglayer",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "A wrapper around logging libraries to provide a consistent way to specify context, metadata, and errors.",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/LogLayer.ts
+++ b/src/LogLayer.ts
@@ -7,6 +7,7 @@ import {
   LogLayerConfig,
   LogLayerContextConfig,
   LogLayerErrorConfig,
+  LogLayerHooksConfig,
   LogLayerMetadataConfig,
   LogLevel,
   MessageDataType,
@@ -22,6 +23,7 @@ export interface LogLayerInternalConfig<ErrorType> {
   error: LogLayerErrorConfig<ErrorType>
   metadata: LogLayerMetadataConfig
   context: LogLayerContextConfig
+  hooks: LogLayerHooksConfig
 }
 
 /**
@@ -39,7 +41,7 @@ export class LogLayer<ExternalLogger extends LoggerLibrary = LoggerLibrary, Erro
 
   _config: LogLayerInternalConfig<ErrorType>
 
-  constructor({ logger, error, context, metadata }: LogLayerConfig<ErrorType>) {
+  constructor({ logger, error, context, metadata, hooks }: LogLayerConfig<ErrorType>) {
     this.loggerInstance = logger.instance
     this.loggerType = logger?.type || LoggerType.OTHER
 
@@ -49,6 +51,7 @@ export class LogLayer<ExternalLogger extends LoggerLibrary = LoggerLibrary, Erro
       error: error || {},
       context: context || {},
       metadata: metadata || {},
+      hooks: hooks || {},
     }
 
     if (!this._config.error.fieldName) {
@@ -260,7 +263,11 @@ export class LogLayer<ExternalLogger extends LoggerLibrary = LoggerLibrary, Erro
       }
     }
 
-    if (hasObjData) {
+    if (this._config.hooks.onBeforeDataOut) {
+      d = this._config.hooks.onBeforeDataOut(hasObjData ? d : undefined)
+    }
+
+    if (d && hasObjData) {
       switch (this.loggerType) {
         case LoggerType.WINSTON:
           // Winston wants the data object to be the last parameter

--- a/src/types.ts
+++ b/src/types.ts
@@ -167,6 +167,30 @@ export interface LogLayerMetadataConfig {
   fieldName?: string
 }
 
+export type HookBeforeDataOutFn<Data extends Record<string, any> = Record<string, any>> = (
+  data?: Data,
+) => Record<string, any> | null | undefined
+
+export interface LogLayerHooksConfig {
+  /**
+   * Called after the assembly of the data object that contains
+   * the metadata / context / error data before being sent to the destination logging
+   * library.
+   *
+   * - The shape of `data` varies depending on your `fieldName` configuration
+   * for metadata / context / error.
+   * - If data was not found for assembly, `undefined` is used as the `data` input.
+   * - You can also create your own object and return it to be sent to the logging library.
+   *
+   * @param Object [data] The object containing metadata / context / error data. This
+   * is null if there is no object with data.
+   *
+   * @returns [Object] The object to be sent to the destination logging
+   * library or null / undefined to not pass an object through.
+   */
+  onBeforeDataOut?: HookBeforeDataOutFn
+}
+
 export interface LogLayerConfig<ErrorType = ErrorDataType> {
   logger: {
     /**
@@ -181,4 +205,5 @@ export interface LogLayerConfig<ErrorType = ErrorDataType> {
   error?: LogLayerErrorConfig<ErrorType>
   metadata?: LogLayerMetadataConfig
   context?: LogLayerContextConfig
+  hooks?: LogLayerHooksConfig
 }


### PR DESCRIPTION
This adds the ability to register hooks with `LogLayer`. The first available hook, `onBeforeDataOut()`, allows manipulation of the data object before it is sent to the logging library.
