### PR TITLE
Add `setHooks()` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ logLayer
       - [Serializing errors](#serializing-errors)
       - [Data output options](#data-output-options)
   - [Hooks](#hooks)
+    - [Set / update hooks outside of configuration](#set--update-hooks-outside-of-configuration)
     - [Modify / create object data before being sent to the logging library](#modify--create-object-data-before-being-sent-to-the-logging-library)
   - [Logging messages](#logging-messages)
   - [Including context with each log message](#including-context-with-each-log-message)
@@ -320,7 +321,7 @@ interface LogLayerConfig {
      * library.
      *
      * - The shape of `data` varies depending on your `fieldName` configuration
-     * for metadata / context / error.
+     * for metadata / context / error. The metadata / context / error data is a *shallow* clone.
      * - If data was not found for assembly, `undefined` is used as the `data` input.
      * - You can also create your own object and return it to be sent to the logging library.
      *
@@ -455,6 +456,13 @@ The same log commands would now be formatted as:
 ```
 
 ### Hooks
+
+#### Set / update hooks outside of configuration
+
+`LogLayer#setHooks(hooks: LogLayerHooksConfig)`
+
+Update hook callback definitions. This is an alternative
+to the `hooks` config option. Only hooks defined will be replaced.
 
 #### Modify / create object data before being sent to the logging library
 

--- a/src/LogLayer.ts
+++ b/src/LogLayer.ts
@@ -86,6 +86,17 @@ export class LogLayer<ExternalLogger extends LoggerLibrary = LoggerLibrary, Erro
   }
 
   /**
+   * Update hook callback definitions. This is an alternative
+   * to the `hooks` config option. Only hooks defined will be replaced.
+   */
+  setHooks(hooks: LogLayerHooksConfig) {
+    this._config.hooks = {
+      ...this._config.hooks,
+      ...hooks,
+    }
+  }
+
+  /**
    * Specifies metadata to include with the log message
    */
   withMetadata(metadata: Record<string, any>) {

--- a/src/__tests__/generic.test.ts
+++ b/src/__tests__/generic.test.ts
@@ -244,6 +244,51 @@ describe('loglayer general tests', () => {
 
   describe('config options', () => {
     describe('hooks config', () => {
+      it('should update hooks', () => {
+        const onBeforeDataOut: HookBeforeDataOutFn = (data) => {
+          if (data) {
+            data.modified = true
+          }
+
+          return data
+        }
+
+        const log = getLogger()
+
+        log.setHooks({
+          onBeforeDataOut,
+        })
+
+        const genericLogger = log.getLoggerInstance()
+        const e = new Error('err')
+
+        log.withContext({
+          contextual: 'data',
+        })
+
+        log
+          .withError(e)
+          .withMetadata({
+            situational: 1234,
+          })
+          .info('combined data')
+
+        expect(genericLogger.getLine()).toStrictEqual(
+          expect.objectContaining({
+            level: LogLevel.info,
+            data: [
+              {
+                err: e,
+                contextual: 'data',
+                situational: 1234,
+                modified: true,
+              },
+              'combined data',
+            ],
+          }),
+        )
+      })
+
       it('should call onBeforeDataOut with context', () => {
         const onBeforeDataOut: HookBeforeDataOutFn = (data) => {
           if (data) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -178,7 +178,7 @@ export interface LogLayerHooksConfig {
    * library.
    *
    * - The shape of `data` varies depending on your `fieldName` configuration
-   * for metadata / context / error.
+   * for metadata / context / error. The metadata / context / error data is a *shallow* clone.
    * - If data was not found for assembly, `undefined` is used as the `data` input.
    * - You can also create your own object and return it to be sent to the logging library.
    *


### PR DESCRIPTION
Adds a new method on `LogLayer` called `setHooks()` that allows
hooks to be set or updated after creation of the `LogLayer`.

Useful as an alternative to using configuration on init to set
a hook