### PR TITLE
Add config option and methods to disable / enable logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ logLayer
   - [Hooks](#hooks)
     - [Set / update hooks outside of configuration](#set--update-hooks-outside-of-configuration)
     - [Modify / create object data before being sent to the logging library](#modify--create-object-data-before-being-sent-to-the-logging-library)
+  - [Disable / enable logging](#disable--enable-logging)
   - [Logging messages](#logging-messages)
   - [Including context with each log message](#including-context-with-each-log-message)
     - [Getting context](#getting-context)
@@ -262,6 +263,15 @@ Generics (all are optional):
 
 ```typescript
 interface LogLayerConfig {
+  /**
+   * Set to false to drop all log input and stop sending to the logging
+   * library.
+   *
+   * Can be re-enabled with `enableLogging()`.
+   *
+   * Default is `true`.
+   */
+  enabled?: boolean
   logger: {
     /**
      * The instance of the logging library to send log data and messages to
@@ -500,6 +510,11 @@ log.withContext({ test: 'data' }).info('this is a test message')
   "msg": "this is a test message"
 }
 ```
+
+### Disable / enable logging
+
+- `LogLayer#enableLogging(): LogLayer`
+- `LogLayer#disableLogging(): LogLayer`
 
 ### Logging messages
 

--- a/src/LogBuilder.ts
+++ b/src/LogBuilder.ts
@@ -93,6 +93,22 @@ export class LogBuilder<ExternalLogger extends LoggerLibrary = LoggerLibrary, Er
     this.formatLog(LogLevel.trace, messages)
   }
 
+  /**
+   * All logging inputs are dropped and stops sending logs to the logging library.
+   */
+  disableLogging() {
+    this.structuredLogger._config.enabled = false
+    return this
+  }
+
+  /**
+   * Enable sending logs to the logging library.
+   */
+  enableLogging() {
+    this.structuredLogger._config.enabled = true
+    return this
+  }
+
   private formatLog(logLevel: LogLevel, params: any[]) {
     const { error: errConfig } = this.structuredLogger._config
 

--- a/src/MockLogBuilder.ts
+++ b/src/MockLogBuilder.ts
@@ -16,4 +16,12 @@ export class MockLogBuilder implements ILogBuilder {
   trace(...messages: MessageDataType[]): void {}
 
   warn(...messages: MessageDataType[]): void {}
+
+  enableLogging() {
+    return this
+  }
+
+  disableLogging() {
+    return this
+  }
 }

--- a/src/MockLogLayer.ts
+++ b/src/MockLogLayer.ts
@@ -34,4 +34,12 @@ export class MockLogLayer<ErrorType = Error> implements ILogLayer<any, ErrorType
   getContext(): Record<string, any> {
     return {}
   }
+
+  enableLogging() {
+    return this
+  }
+
+  disableLogging() {
+    return this
+  }
 }

--- a/src/__tests__/generic.test.ts
+++ b/src/__tests__/generic.test.ts
@@ -70,6 +70,42 @@ describe('loglayer general tests', () => {
     })
   })
 
+  it('should toggle log output', () => {
+    const log = getLogger({ enabled: false })
+    const genericLogger = log.getLoggerInstance()
+
+    log.info('test')
+    expect(genericLogger.getLine()).not.toBeDefined()
+
+    log.enableLogging()
+    log.info('test')
+    expect(genericLogger.getLine()).toStrictEqual(
+      expect.objectContaining({
+        level: 'info',
+        data: ['test'],
+      }),
+    )
+
+    log.disableLogging()
+    log.info('test')
+    expect(genericLogger.getLine()).not.toBeDefined()
+
+    // Test LogBuilder
+    log.enableLogging()
+    log.withMetadata({}).disableLogging().info('test')
+    expect(genericLogger.getLine()).not.toBeDefined()
+
+    // This doesn't immediately enable log output
+    log.withMetadata({}).enableLogging().info('test')
+
+    expect(genericLogger.getLine()).toStrictEqual(
+      expect.objectContaining({
+        level: 'info',
+        data: [{}, 'test'],
+      }),
+    )
+  })
+
   it('should include context', () => {
     const log = getLogger()
     const genericLogger = log.getLoggerInstance()

--- a/src/types.ts
+++ b/src/types.ts
@@ -192,6 +192,15 @@ export interface LogLayerHooksConfig {
 }
 
 export interface LogLayerConfig<ErrorType = ErrorDataType> {
+  /**
+   * Set to false to drop all log input and stop sending to the logging
+   * library.
+   *
+   * Can be re-enabled with `enableLogging()`.
+   *
+   * Default is `true`.
+   */
+  enabled?: boolean
   logger: {
     /**
      * The instance of the logging library to send log data and messages to


### PR DESCRIPTION
This adds an optional config option called `enabled`, when set to `false`, will stop log output.

Corresponding methods `enableLogging()` and `disableLogging()` have also been added.