### PR TITLE
Add support for creating child loggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ logLayer
       - [Supported log library types](#supported-log-library-types)
       - [Serializing errors](#serializing-errors)
       - [Data output options](#data-output-options)
+  - [Child logger](#child-logger)
   - [Hooks](#hooks)
     - [Set / update hooks outside of configuration](#set--update-hooks-outside-of-configuration)
     - [Modify / create object data before being sent to the logging library](#modify--create-object-data-before-being-sent-to-the-logging-library)
@@ -472,6 +473,20 @@ The same log commands would now be formatted as:
     "reqId": 1234
   }
 }
+```
+
+### Child logger
+
+You can create a child logger, which will copy the configuration you used for creating the parent, along with the existing
+context data.
+
+The copied context data is a *shallow copy*.
+
+```
+const parentLog = new LogLayer(<config>).withContext({ some: 'data' })
+
+// Creates a new LogLayer with <config> copied over and the context
+const childLog = parentLog.child()
 ```
 
 ### Hooks

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loglayer",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "description": "A wrapper around logging libraries to provide a consistent way to specify context, metadata, and errors.",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/LogLayer.ts
+++ b/src/LogLayer.ts
@@ -115,6 +115,20 @@ export class LogLayer<ExternalLogger extends LoggerLibrary = LoggerLibrary, Erro
   }
 
   /**
+   * Creates a new instance of LogLayer but with the initialization
+   * configuration and context copied over.
+   */
+  child() {
+    return new LogLayer<ExternalLogger, ErrorType>({
+      ...this._config,
+      logger: {
+        instance: this.loggerInstance,
+        type: this.loggerType,
+      },
+    }).withContext(this.context)
+  }
+
+  /**
    * Logs only the error object without a log message
    */
   errorOnly(error: ErrorType, opts?: ErrorOnlyOpts) {

--- a/src/MockLogLayer.ts
+++ b/src/MockLogLayer.ts
@@ -42,4 +42,8 @@ export class MockLogLayer<ErrorType = Error> implements ILogLayer<any, ErrorType
   disableLogging() {
     return this
   }
+
+  child() {
+    return new MockLogLayer({})
+  }
 }

--- a/src/__tests__/generic.test.ts
+++ b/src/__tests__/generic.test.ts
@@ -53,6 +53,56 @@ function getLogger(config?: Partial<LogLayerConfig>) {
 }
 
 describe('loglayer general tests', () => {
+  it('should create a child logger with only the original configuration and context', () => {
+    const origLog = getLogger().withContext({
+      test: 'context',
+    })
+
+    const parentGenericLogger = origLog.getLoggerInstance()
+
+    // Add additional context to the child logger
+    const childLog = origLog.child().withContext({
+      child: 'childData',
+    })
+
+    childLog.info('test')
+
+    const childGenericLogger = childLog.getLoggerInstance()
+
+    expect(childGenericLogger.getLine()).toStrictEqual(
+      expect.objectContaining({
+        level: LogLevel.info,
+        data: [
+          {
+            test: 'context',
+            child: 'childData',
+          },
+          'test',
+        ],
+      }),
+    )
+
+    // make sure the parent logger doesn't have the additional context of the child
+    origLog
+      .withContext({
+        parentContext: 'test-2',
+      })
+      .info('parent-test')
+
+    expect(parentGenericLogger.getLine()).toStrictEqual(
+      expect.objectContaining({
+        level: LogLevel.info,
+        data: [
+          {
+            test: 'context',
+            parentContext: 'test-2',
+          },
+          'parent-test',
+        ],
+      }),
+    )
+  })
+
   it('should write messages', () => {
     const log = getLogger()
     const genericLogger = log.getLoggerInstance()

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,6 +83,14 @@ export interface ILogLayer<ExternalLogger extends LoggerLibrary = LoggerLibrary,
    * Returns the context used for the logger
    */
   getContext(): Record<string, any>
+
+  /**
+   * Creates a new instance of LogLayer but with the initialization
+   * configuration and context data copied over.
+   *
+   * The copied context data is a *shallow copy*.
+   */
+  child(): ILogBuilder
 }
 
 export enum LogLevel {


### PR DESCRIPTION
This adds a new method called LogLayer#child() that will create a new LogLayer instance with the original configuration and context data copied over.

Addresses #6 