### PR TITLE
Fix issue where `LogLayer#child()` was not creating a shallow copy of context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Add support for creating child loggers (#9)
 
-This adds a new method called LogLayer#child() that will create a new LogLayer instance with the original configuration and context data copied over.
+This adds a new method called `LogLayer#child()` that will create a new LogLayer instance with the original configuration and context data copied over.
 
 ## 1.3.4 - Mon Aug 22 2022 20:18:36
 

--- a/README.md
+++ b/README.md
@@ -477,6 +477,8 @@ The same log commands would now be formatted as:
 
 ### Child logger
 
+`LogLayer#child()`
+
 You can create a child logger, which will copy the configuration you used for creating the parent, along with the existing
 context data.
 

--- a/src/LogLayer.ts
+++ b/src/LogLayer.ts
@@ -125,7 +125,9 @@ export class LogLayer<ExternalLogger extends LoggerLibrary = LoggerLibrary, Erro
         instance: this.loggerInstance,
         type: this.loggerType,
       },
-    }).withContext(this.context)
+    }).withContext({
+      ...this.context,
+    })
   }
 
   /**


### PR DESCRIPTION
The documentation says the context should be shallow copied, but it wasn't. Now it is.